### PR TITLE
Migrate from `name.full()` to `name_full()` to future-proof editing a user into an organization

### DIFF
--- a/docassemble/FinancialAffidavit/data/questions/fa_additional.yml
+++ b/docassemble/FinancialAffidavit/data/questions/fa_additional.yml
@@ -20,15 +20,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "creditor_name_7": |
         % if debts.number_gathered() >= 7:
@@ -377,15 +377,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "cash_bank_name_4": |
         % if cash.number_gathered() >= 4:
@@ -761,15 +761,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "cd_bank_name_4": |
         % if cert_deposit.number_gathered() >= 4:
@@ -1059,15 +1059,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "money_card_4": |
         % if money.number_gathered() >= 4:
@@ -1355,15 +1355,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "investment_name_4": |
         % if investments.number_gathered() >= 4:
@@ -1828,15 +1828,15 @@ attachment:
     - "petitioner_name": |
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "other_investments_description_4": |
         % if other_investments.number_gathered() >= 4:
@@ -2124,15 +2124,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "real_estate_address_4": |
         % if real_estate.number_gathered() >= 4:
@@ -2508,15 +2508,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "motor_vehicle_info_4": |
         See Financial Affidavit 15d4
@@ -2879,15 +2879,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "business_interests_name_4": |
         % if business_interests.number_gathered() >= 4:
@@ -3265,15 +3265,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "life_insurance_company_4": |
         % if life_insurance.number_gathered() >= 4:
@@ -3651,15 +3651,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "retirement_plan_4": |
         % if retirement_plan.number_gathered() >= 4:
@@ -3949,15 +3949,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "collection_description_4": |
         % if collection.number_gathered() >= 4:
@@ -4159,15 +4159,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "other_property_description_4": |
         % if other_property.number_gathered() >= 4:
@@ -4368,15 +4368,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "transfer_description_4": |
         % if transfer.number_gathered() >= 4:
@@ -4752,15 +4752,15 @@ attachment:
     - "post-judgment": ${ filing_status == "post_judgment" }
     - "petitioner_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % else:
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % endif
     - "respondent_name": |
         % if party_label == 'petitioner' or party_label == 'plaintiff':
-        ${ other_parties[0].name.full(middle='full') }
+        ${ other_parties[0].name_full() }
         % else:
-        ${ users[0].name.full(middle='full') }
+        ${ users[0].name_full() }
         % endif
     - "lawsuit_number_4": |
         % if lawsuits.number_gathered() >= 4:

--- a/docassemble/FinancialAffidavit/data/questions/financial_affidavit.yml
+++ b/docassemble/FinancialAffidavit/data/questions/financial_affidavit.yml
@@ -2963,7 +2963,7 @@ id: e-signature
 question: |
   Do you want to add your e-signature to your ${ form_name }?
 subquestion: |
-  This program can put "**/s/ ${users[0].name.full(middle='full')}**" where you would sign your name. The court will accept this as your signature.
+  This program can put "**/s/ ${users[0].name_full()}**" where you would sign your name. The court will accept this as your signature.
 
   If you do not add your **{e-signature}**, you must sign your paper form before you send it to the other party in your case or their lawyer.
 
@@ -3085,15 +3085,15 @@ attachment:
       - "post-judgment": ${ filing_status == "post_judgment" }
       - "petitioner_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % else:
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % endif
       - "respondent_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % else:
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % endif
       - "petitioner_yes": ${ party_label == 'petitioner' or party_label == 'plaintiff' }
       - "respondent_yes": ${ party_label == 'respondent' or party_label == 'defendant' }
@@ -3110,7 +3110,7 @@ attachment:
           % if users[0].attached_documents["other"]:
           ${ comma_and_list(users[0].attachment_assets) }
           % endif
-      - "users_name": ${ users[0].name.full(middle='full') }
+      - "users_name": ${ users[0].name_full() }
       - "users_phone_number": |
           % if not hide_contact:
           ${ phone_number_formatted(users[0].phone_number) }
@@ -4931,7 +4931,7 @@ attachment:
           % endif
 
       - "users_signature": |
-          ${ "/s/ " + users[0].name.full(middle="full") if e_signature else ''  }
+          ${ "/s/ " + users[0].name_full() if e_signature else ''  }
       - "users_signed_date": ${ today().format("MM/dd/yyyy") if e_signature else '' }
 
 ---
@@ -4974,15 +4974,15 @@ attachment:
       - "post-judgment": ${ filing_status == "post_judgment" }
       - "petitioner_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % else:
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % endif
       - "respondent_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % else:
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % endif
 
       - "employed_yes": ${ employment[i].type == 'employed' }
@@ -5123,15 +5123,15 @@ attachment:
       - "post-judgment": ${ filing_status == "post_judgment" }
       - "petitioner_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % else:
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % endif
       - "respondent_name": |
           % if party_label == 'petitioner' or party_label == 'plaintiff':
-          ${ other_parties[0].name.full(middle='full') }
+          ${ other_parties[0].name_full() }
           % else:
-          ${ users[0].name.full(middle='full') }
+          ${ users[0].name_full() }
           % endif
 
       - "health_insurance_yes": ${ insurance.there_are_any }

--- a/docassemble/FinancialAffidavit/data/questions/section_reviews.yml
+++ b/docassemble/FinancialAffidavit/data/questions/section_reviews.yml
@@ -118,7 +118,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: party_label
     button: |
       **Your party label:**
@@ -126,7 +126,7 @@ review:
   - Edit: other_parties[0].name.first
     button: |
       **The other party's name:**
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
   - Edit: case_county
     button: |
       **County where this case is filed:**
@@ -869,7 +869,7 @@ review:
   - Edit: users[0].name.first
     button: |
       **Your name:**
-      ${users[0].name.full(middle="full")}
+      ${users[0].name_full()}
   - Edit: party_label
     button: |
       **Your party label:**
@@ -877,7 +877,7 @@ review:
   - Edit: other_parties[0].name.first
     button: |
       **The other party's name:**
-      ${other_parties[0].name.full(middle="full")}
+      ${other_parties[0].name_full()}
   - Edit: case_county
     button: |
       **County where this case is filed:**


### PR DESCRIPTION

Previously, it was possible to have leftover text in the .name.last field which would not be removed
if the user used a review screen and changed the person type from Individual to Business.

This PR replaces any use of `.name.full(middle="full")` with `name_full()`, which in a future
version of the AssemblyLine framework will solve this problem by not printing the last name
when the `person_type` is "business"

## How this change was made

This change was made by searching for any repos that had the text `name.full(middle="full") using gh-search,
and then the text was replaced with turbolift --sed as follows:

```bash
turbolift foreach -- bash -lc '
  # 1) enable ** to recurse
  shopt -s globstar

  # 2) for each .yml, replace both " and '\'' variants
  for f in **/*.yml; do
    sed -i "s/name\.full(middle=\"full\")/name_full()/g" "$f"
    sed -i "s/name\.full(middle='\''full'\'')/name_full()/g" "$f"
  done
'
```

<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>